### PR TITLE
Fix mkdir detection with native hook

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,3 +43,4 @@ dev-rikka-rikkax-material = { module = "dev.rikka.rikkax.material:material", ver
 dev-rikka-rikkax-material-preference = { module = "dev.rikka.rikkax.material:material-preference", version = "2.0.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
 me-zhanghai-android-appiconloader = { module = "me.zhanghai.android.appiconloader:appiconloader", version = "1.5.0" }
+lsposed-nativehook = { module = "io.github.vvb2060:nativehook", version = "1.2.1" }

--- a/xposed/build.gradle.kts
+++ b/xposed/build.gradle.kts
@@ -12,6 +12,23 @@ plugins {
 android {
     namespace = "icu.nullptr.hidemyapplist.xposed"
 
+    defaultConfig {
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+        }
+        externalNativeBuild {
+            cmake {
+                cppFlags += "-std=c++17"
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
+    }
+
     buildFeatures {
         buildConfig = false
     }
@@ -68,6 +85,7 @@ dependencies {
     implementation(libs.com.android.tools.build.apksig)
     implementation(libs.com.github.kyuubiran.ezxhelper)
     implementation(libs.dev.rikka.hidden.compat)
+    implementation(libs.lsposed.nativehook)
     compileOnly(libs.de.robv.android.xposed.api)
     compileOnly(libs.dev.rikka.hidden.stub)
 }

--- a/xposed/src/main/cpp/CMakeLists.txt
+++ b/xposed/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.6)
+project(hma_native)
+
+add_library(hma_native SHARED mkdir_hook.cpp)
+
+find_library(log-lib log)
+
+# nativehook provides a cmake config for prefab
+find_package(nativehook REQUIRED CONFIG)
+
+target_link_libraries(hma_native
+    nativehook
+    ${log-lib}
+)

--- a/xposed/src/main/cpp/mkdir_hook.cpp
+++ b/xposed/src/main/cpp/mkdir_hook.cpp
@@ -1,0 +1,19 @@
+#include <cstring>
+#include <cerrno>
+#include <sys/stat.h>
+#include <android/log.h>
+#include <nativehook/nativehook.h>
+
+static int (*orig_mkdir)(const char *, mode_t) = nullptr;
+
+static int hooked_mkdir(const char *pathname, mode_t mode) {
+    if (pathname && strncmp(pathname, "/storage/emulated/0/Android/data/", 32) == 0) {
+        errno = EACCES; // Permission denied
+        return -1;
+    }
+    return orig_mkdir(pathname, mode);
+}
+
+static void __attribute__((constructor)) init() {
+    nativehook::HookSymbol("libc.so", "mkdir", (void *)hooked_mkdir, (void **)&orig_mkdir);
+}

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/XposedEntry.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/XposedEntry.kt
@@ -8,6 +8,7 @@ import de.robv.android.xposed.IXposedHookZygoteInit
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import icu.nullptr.hidemyapplist.common.Constants
+import icu.nullptr.hidemyapplist.xposed.nativehook.NativeHookLoader
 import kotlin.concurrent.thread
 
 private const val TAG = "HMA-XposedEntry"
@@ -17,6 +18,7 @@ class XposedEntry : IXposedHookZygoteInit, IXposedHookLoadPackage {
 
     override fun initZygote(startupParam: IXposedHookZygoteInit.StartupParam) {
         EzXHelperInit.initZygote(startupParam)
+        NativeHookLoader
     }
 
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/nativehook/NativeHook.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/nativehook/NativeHook.kt
@@ -1,0 +1,10 @@
+package icu.nullptr.hidemyapplist.xposed.nativehook
+
+import icu.nullptr.hidemyapplist.xposed.logE
+
+object NativeHookLoader {
+    init {
+        runCatching { System.loadLibrary("hma_native") }
+            .onFailure { logE("NativeHook", "Failed to load native library", it) }
+    }
+}


### PR DESCRIPTION
## Summary
- add LSPosed native hook dependency
- configure xposed module to build native code
- create native hook returning EACCES for mkdir under `Android/data`
- load native library at zygote init

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683d60c7bcc8832396c92d511af6c46b